### PR TITLE
FIXED - Including Reachability.m causes duplicate symbols at compile time

### DIFF
--- a/EVURLCache.m
+++ b/EVURLCache.m
@@ -8,7 +8,7 @@
 #import "EVURLCache.h"
 #import <sys/stat.h>
 #include <sys/xattr.h>
-#include "Reachability.m"
+#include "Reachability.h"
 
 static NSString* _cacheDirectory;
 static NSString* _preCacheDirectory;


### PR DESCRIPTION
Including Reachability.m causes duplicate symbols at compile time.

Including Reachability.h instead fixes the problem.
