### PR TITLE
Fix crash caused by NSURLRequest with empty string URL

### DIFF
--- a/EVURLCache/Pod/EVURLCache.swift
+++ b/EVURLCache/Pod/EVURLCache.swift
@@ -53,6 +53,16 @@ public class EVURLCache : NSURLCache {
     
     // Will be called by a NSURLConnection when it's wants to know if there is something in the cache.
     public override func cachedResponseForRequest(request: NSURLRequest) -> NSCachedURLResponse? {
+        guard let _ = request.URL else {
+            EVURLCache.debugLog("CACHE not allowed for nil URLs");
+            return nil
+        }
+        
+        if request.URL!.absoluteString.isEmpty {
+            EVURLCache.debugLog("CACHE not allowed for empty URLs");
+            return nil;
+        }
+        
         // is caching allowed
         if ((request.cachePolicy == NSURLRequestCachePolicy.ReloadIgnoringCacheData || request.URL!.absoluteString.hasPrefix("file:/") || request.URL!.absoluteString.hasPrefix("data:")) && EVURLCache.networkAvailable()) {
             EVURLCache.debugLog("CACHE not allowed for \(request.URL)");


### PR DESCRIPTION
If you attempt to perform a request with an empty string URL, EVURLCache crashes here:

    public static func storagePathForRequest(request: NSURLRequest, rootPath: String) -> String { 
        // ...
        // crash is on next line:
        if let storageFile: String = localUrl.componentsSeparatedByString("/").last {
            if !storageFile.containsString(".")  {
                localUrl = "/\(localUrl)/index.html"
            }
        }
        // ...
    }

Because at this point, localURL is nil, where it is expected to have a value. This fix exits early from:

    public override func cachedResponseForRequest(request: NSURLRequest) -> NSCachedURLResponse? {

so that the invalid URL is never passed into `storagePathForRequest`.