### PR TITLE
FIX writing cache data failure when url contains percent escape encoding

### DIFF
--- a/EVURLCache/Pod/EVURLCache.swift
+++ b/EVURLCache/Pod/EVURLCache.swift
@@ -129,7 +129,7 @@ public class EVURLCache : NSURLCache {
         
         // create storrage folder
         let storagePath: String = EVURLCache.storagePathForRequest(request, rootPath: EVURLCache._cacheDirectory)
-        if var storageDirectory: String = NSURL(fileURLWithPath: "\(storagePath)").URLByDeletingLastPathComponent?.absoluteString {
+        if var storageDirectory: String = NSURL(fileURLWithPath: "\(storagePath)").URLByDeletingLastPathComponent?.absoluteString.stringByRemovingPercentEncoding {
             do {
                 if storageDirectory.hasPrefix("file:") {
                     storageDirectory = storageDirectory.substringFromIndex(storageDirectory.startIndex.advancedBy(5))


### PR DESCRIPTION
If i load url like "http://game.zorropk.com/gamenow/gamecenterbox/%E5%B0%8F%E4%BA%94%E6%B5%B7%E6%B4%8B%E5%8E%86%E9%99%A9%E8%AE%B01/", writing cache data to disk will fail, output log shows: "Could not write file to cache",  
the reason is, on line 131-132, storagePath had remove percent escape while storageDirectory still contain percent escape encoding.