### PR TITLE
Added 'open' protection level for cleanExpiredCaches method.

### DIFF
--- a/EVURLCache/Pod/EVURLCache.swift
+++ b/EVURLCache/Pod/EVURLCache.swift
@@ -328,7 +328,7 @@ open class EVURLCache: URLCache {
     
     
     // Removes all files from _cacheDirectory with modification date more than MAX_AGE ago
-    static func cleanExpiredCaches() {
+    open static func cleanExpiredCaches() {
         let defaultFileManager = FileManager.default
         
         let storagePath = EVURLCache._cacheDirectory


### PR DESCRIPTION
Sorry. I missed to add 'open' protection level for this method.